### PR TITLE
Fixed typescript error

### DIFF
--- a/fresh-webcomponent/routes/index.tsx
+++ b/fresh-webcomponent/routes/index.tsx
@@ -1,6 +1,7 @@
 import { useSignal } from "@preact/signals";
 import { Head } from "$fresh/runtime.ts";
 import Counter from "../islands/Counter.tsx";
+import { JSX } from "preact";
 
 declare module "preact" {
   namespace JSX {
@@ -10,7 +11,7 @@ declare module "preact" {
   }
 }
 
-interface StopWatchAttributes extends preact.JSX.HTMLAttributes<HTMLElement> {
+interface StopWatchAttributes extends JSX.HTMLAttributes<HTMLElement> {
   kind?: string;
 }
 


### PR DESCRIPTION
I have been working on a blog about using web components with Deno and put that knowledge into use to fix the TypeScript errors in `index.tsx`.

My repo can be found here: https://github.com/cdoremus/deno-fresh-webcomponents

